### PR TITLE
Use msbuild instead of devenv (or vcexpress)

### DIFF
--- a/buildVC2010.bat
+++ b/buildVC2010.bat
@@ -155,9 +155,9 @@ echo ==============================
 
 cd %srcroot%\regex
 if "%ARCH%" == "x86" (
-	devenv /build "%CONF%|Win32" /project regex regex.sln
+	msbuild regex.sln /property:Configuration=%CONF% /property:Platform=Win32
 ) else (
-	devenv /build "%CONF%|x64" /project regex regex.sln
+	msbuild regex.sln /property:Configuration=%CONF% /property:Platform=x64
 )
 
 set REGEX_RESULT=%ERRORLEVEL%


### PR DESCRIPTION
http://stackoverflow.com/questions/7818543/no-devenv-file-in-microsoft-visual-express-10
In Visual C++ 2010 Express, buildVC2010.bat had to be hand-edited to use vcexpress instead of devenv.
https://msdn.microsoft.com/en-us/library/xee0c8y7.aspx "For build-related tasks, it is now recommended that you use MSBuild instead of devenv."