### PR TITLE
Fix zlib build success/fail report message

### DIFF
--- a/buildVC2017.bat
+++ b/buildVC2017.bat
@@ -255,7 +255,7 @@ if %PDCURSES_RESULT% == 0 (
 ) else (
 	echo PDCurses ............... FAILED!
 )
-if %PDCURSES_RESULT% == 0 (
+if %ZLIB_RESULT% == 0 (
 	echo zlib ................... SUCCESS!
 ) else (
 	echo zlib ................... FAILED!


### PR DESCRIPTION
This fixes an issue where the script was reporting the build result of PDCurses when it was supposed to report the build result of zlib.