### PR TITLE
Warning on macOS when the working path has spaces in it

### DIFF
--- a/buildmacOS.sh
+++ b/buildmacOS.sh
@@ -1,11 +1,26 @@
 #!/bin/bash
 
+ORIGROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SRCROOT=$ORIGROOT/src
+
+# check for spaces in path
+ESCAPEDORIGROOT=$(printf %q "$ORIGROOT")
+if [[ "$ORIGROOT" != "$ESCAPEDORIGROOT" ]] ; then
+	echo "This script has detected that the path to its parent directory contains spaces"
+	echo "or other special characters. The build systems of some of our dependencies do"
+	echo "not support escaped paths, so building is likely to fail. Please move the"
+	echo "parent directory of this script to a location without spaces or other special"
+	echo "characters in its path, then try building again."
+	echo
+	echo "Press enter to continue anyway, or Ctrl-C to cancel."
+	read -rs
+	echo
+fi
+
 function buildDeps {
 	ARCH=$1
 	CONF=$2
 
-	ORIGROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-	SRCROOT=$ORIGROOT/src
 	OUTPUTROOT=$ORIGROOT/dependencies/output-macOS-$CONF-$ARCH
 
 	mkdir -p $OUTPUTROOT


### PR DESCRIPTION
Despite my best efforts, I could not make our dependencies build on macOS when there are spaces in the path.  I tried every method of quoting and escaping that I found in my research, but whatever worked for one library always broke another.  As a second-best option, this will just check for a path that needs to be escaped, and will warn the user to fix it before building.

I don't believe the Windows script works with spaces in the path either, so we might consider doing something similar in that script.