### PR TITLE
Enable building both x86_64 and arm64 architectures on macOS

### DIFF
--- a/buildmacOS.sh
+++ b/buildmacOS.sh
@@ -80,7 +80,7 @@ function buildDeps {
 	cd $SRCROOT/c-ares
 
 	cp include/ares_build.h include/ares_build.h.bak &&
-	if [[ $CONF == "debug" ]] ; then
+	if [[ $CONF == "Debug" ]] ; then
 		./configure --prefix=$OUTPUTROOT --host=$BUILD_HOST --disable-shared --disable-tests --enable-debug
 	else
 		./configure --prefix=$OUTPUTROOT --host=$BUILD_HOST --disable-shared --disable-tests
@@ -103,7 +103,7 @@ function buildDeps {
 
 	cd $SRCROOT/glew
 
-	if [[ $CONF == "debug" ]] ; then
+	if [[ $CONF == "Debug" ]] ; then
 		make glew.lib.static GLEW_DEST=$OUTPUTROOT SYSTEM=darwin CFLAGS.EXTRA="$CFLAGS" STRIP= &&
 		make install GLEW_DEST=$OUTPUTROOT STRIP=
 	else
@@ -161,10 +161,10 @@ function buildDeps {
 }
 
 # build these configurations
-buildDeps x86_64 release
-buildDeps x86_64 debug
-buildDeps arm64 release
-buildDeps arm64 debug
+buildDeps x86_64 Release
+buildDeps x86_64 Debug
+buildDeps arm64 Release
+buildDeps arm64 Debug
 
 echo "#######################"
 echo "# Final build results #"

--- a/buildmacOS.sh
+++ b/buildmacOS.sh
@@ -39,7 +39,7 @@ function buildDeps {
 	mkdir -p $OUTPUTROOT/include
 	mkdir -p $ORIGROOT/dependencies/licenses
 
-	export MACOSX_DEPLOYMENT_TARGET=10.9
+	export MACOSX_DEPLOYMENT_TARGET=10.13
 	export CPPFLAGS="-I$OUTPUTROOT/include"
 	export CFLAGS="-arch $ARCH"
 	export CXXFLAGS="-arch $ARCH"

--- a/buildmacOS.sh
+++ b/buildmacOS.sh
@@ -17,6 +17,16 @@ if [[ "$ORIGROOT" != "$ESCAPEDORIGROOT" ]] ; then
 	echo
 fi
 
+function printHeading {
+	if [[ "$#" -gt 0 ]] ; then
+		NUM_CHARS="$(echo -n "$1" | wc -c)"
+		while [[ "$NUM_CHARS" -gt 0 ]] ; do printf "=" ; NUM_CHARS="$(($NUM_CHARS - 1))" ; done ; echo
+		echo $1
+		NUM_CHARS="$(echo -n "$1" | wc -c)"
+		while [[ "$NUM_CHARS" -gt 0 ]] ; do printf "=" ; NUM_CHARS="$(($NUM_CHARS - 1))" ; done ; echo
+	fi
+}
+
 function buildDeps {
 	ARCH=$1
 	CONF=$2
@@ -35,9 +45,9 @@ function buildDeps {
 	export CXXFLAGS="-arch $ARCH"
 	export LDFLAGS="-L$OUTPUTROOT/lib -arch $ARCH"
 
-	echo "=============================="
-	echo "Building libpng ($CONF)"
-	echo "=============================="
+	############################################
+	printHeading "Building libpng ($ARCH $CONF)"
+	############################################
 
 	cd $SRCROOT/libpng
 
@@ -54,9 +64,9 @@ function buildDeps {
 
 	echo
 
-	echo "=============================="
-	echo "Building c-ares ($CONF)"
-	echo "=============================="
+	############################################
+	printHeading "Building c-ares ($ARCH $CONF)"
+	############################################
 
 	cd $SRCROOT/c-ares
 
@@ -78,9 +88,9 @@ function buildDeps {
 
 	echo
 
-	echo "=============================="
-	echo "Building GLEW ($CONF)"
-	echo "=============================="
+	##########################################
+	printHeading "Building GLEW ($ARCH $CONF)"
+	##########################################
 
 	cd $SRCROOT/glew
 
@@ -101,9 +111,9 @@ function buildDeps {
 
 	echo
 
-	echo "=============================="
-	echo "Building SDL2 ($CONF)"
-	echo "=============================="
+	##########################################
+	printHeading "Building SDL2 ($ARCH $CONF)"
+	##########################################
 
 	cd $SRCROOT/SDL2
 
@@ -122,9 +132,9 @@ function buildDeps {
 
 	echo
 
-	echo "=============================="
-	echo "Copying glm ($CONF)"
-	echo "=============================="
+	########################################
+	printHeading "Copying glm ($ARCH $CONF)"
+	########################################
 
 	cd $SRCROOT/glm
 


### PR DESCRIPTION
This change enables the macOS build script to build both Intel (x86_64) and ARM (arm64) dependency packages.  I tested it on both an Intel Mac and an Apple silicon Mac (macOS Monterey in both cases), and the dependencies appeared to be built correctly for all architectures and configurations in both cases.

I saw quite a bit of literature out there regarding different approaches to cross-compiling, but what ultimately worked for me was passing the `--host` option to `configure` where applicable, in combination with the `-arch` option to `CFLAGS`/`CXXFLAGS`/`LDFLAGS` (which we had already).  GLEW was a special case since it uses a custom makefile and not automake like the others.  That being said, if anyone is more familiar with setting up cross-compiling, please chime in.