### PR TITLE
bring overdue readme info about dependencies and link to a browsable official source of libpng

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,24 +13,26 @@ Here is a list of the upstream source locations:
 * [PDCurses](http://sourceforge.net/projects/pdcurses/files/pdcurses/)
 * regex - Looks like it was some version from NetBSD. Haven't yet found the ideal location to pull a
   new version from, so I'm using what we had.
-* [libpng](https://git.code.sf.net/p/libpng/)
+* [libpng](https:/github.com/pnggroup/libpng)
 * [GLEW](http://glew.sourceforge.net/)
 * [SDL2](https://libsdl.org/)
 * [zlib](https://github.com/madler/zlib)
 
+When new versions of these dependencies are released, we should update our copies. Just delete the contents and replace
+with the new contents of the source tars (not zips). This should be done on a Linux or macOS system so that the execute
+permission on scripts is preserved.
+
+## Requirements
+
+On Windows, you must have Visual Studio 2017 installed with at least "Desktop development with C++".
+
+For macOS, you must have Xcode installed. Additionally, autoconf and automake from homebrew are currently needed to
+build c-ares.
+
 ## Building the libraries
 
-A batch file to build for Visual C++ 2017 is provided. Run the buildVC2017.bat file and it should
-build the libraries. Output will go into a folder such as output-release-x86. Run a 
-'git clean -x -f -d' before switching between Visual C++ versions.
+On Windows, run buildVC2017.bat. On macOS, run buildmacOS.sh.
 
 ## Using the libraries
 
-Create an environment variable called BZ_DEPS that points to the directory that the output
-directories are contained within. For instance, if output-release-x86 is at
-'D:\bzflag-dependencies\output-release-x86', then BZ_DEPS should be 'D:\bzflag-dependencies\'.
-
-## Updating the libraries
-
-When new versions of these dependencies are released, we should update our copies. Just delete the contents and replace with the new contents of the source tars (not zips). This should be done on a Linux or macOS system so that the execute permission on scripts is preserved.
-
+Copy the "dependencies" folder to the game source code directory. It should be alongside include and src.


### PR DESCRIPTION
the previous sourceforge git link gave 404 when trying to visit it. i've confirmed the github is the official repository alongside sourceforge

also brought up the changes from 2.4 about the dependencies directory which should've been put here long ago