### PR TITLE
backport upstream patch for building on macos

### DIFF
--- a/src/libpng/pngpriv.h
+++ b/src/libpng/pngpriv.h
@@ -514,18 +514,8 @@
     */
 #  include <float.h>
 
-#  if (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
-    defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)
-   /* We need to check that <math.h> hasn't already been included earlier
-    * as it seems it doesn't agree with <fp.h>, yet we should really use
-    * <fp.h> if possible.
-    */
-#    if !defined(__MATH_H__) && !defined(__MATH_H) && !defined(__cmath__)
-#      include <fp.h>
-#    endif
-#  else
-#    include <math.h>
-#  endif
+#  include <math.h>
+
 #  if defined(_AMIGA) && defined(__SASC) && defined(_M68881)
    /* Amiga SAS/C: We must include builtin FPU functions when compiling using
     * MATH=68881


### PR DESCRIPTION
libpng macos builds were broken for a while most likely, 1.6.41 release fixed this but easier to backport the individual patch to avoid other complications
commit: https://github.com/pnggroup/libpng/commit/893b8113f04d408cc6177c6de19c9889a48faa24 pull request: pnggroup/libpng#529
apologies for the unclear commit title, as in forgetting to mention libpng 